### PR TITLE
sorts pool cards by own stake and total avax stake

### DIFF
--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -4,15 +4,13 @@ import { RowBetween } from '../Row'
 import styled from 'styled-components'
 import { TYPE, StyledInternalLink } from '../../theme'
 import DoubleCurrencyLogo from '../DoubleLogo'
-import { CAVAX, JSBI, TokenAmount, WAVAX, Token, Fraction } from '@pangolindex/sdk'
+import { CAVAX, JSBI, Token } from '@pangolindex/sdk'
 import { ButtonPrimary } from '../Button'
 import { StakingInfo } from '../../state/stake/hooks'
 import { useColor } from '../../hooks/useColor'
 import { currencyId } from '../../utils/currencyId'
 import { Break, CardNoise, CardBGImage } from './styled'
 import { unwrappedToken } from '../../utils/wrappedCurrency'
-import { useTotalSupply } from '../../data/TotalSupply'
-import { usePair } from '../../data/Reserves'
 // import useUSDCPrice from '../../utils/useUSDCPrice'
 import { PNG } from '../../constants'
 
@@ -83,83 +81,22 @@ export default function PoolCard({ stakingInfo }: { stakingInfo: StakingInfo }) 
 	const isStaking = Boolean(stakingInfo.stakedAmount.greaterThan('0'))
 
 	const avaxPool = currency0 === CAVAX || currency1 === CAVAX
-
-	let valueOfTotalStakedAmountInWavax: TokenAmount | undefined
-	// let valueOfTotalStakedAmountInUSDC: CurrencyAmount | undefined
-	let backgroundColor: string
 	let token: Token
-	const totalSupplyOfStakingToken = useTotalSupply(stakingInfo.stakedAmount.token)
-	const [, stakingTokenPair] = usePair(...stakingInfo.tokens)
-	const [, avaxPngTokenPair] = usePair(CAVAX, PNG[token1.chainId])
-	// let usdToken: Token
 	if (avaxPool) {
 		token = currency0 === CAVAX ? token1 : token0
-		const wavax = currency0 === CAVAX ? token0 : token1
-
-		// let returnOverMonth: Percent = new Percent('0')
-		if (totalSupplyOfStakingToken && stakingTokenPair) {
-			// take the total amount of LP tokens staked, multiply by AVAX value of all LP tokens, divide by all LP tokens
-			valueOfTotalStakedAmountInWavax = new TokenAmount(
-				wavax,
-				JSBI.divide(
-					JSBI.multiply(
-						JSBI.multiply(stakingInfo.totalStakedAmount.raw, stakingTokenPair.reserveOf(wavax).raw),
-						JSBI.BigInt(2) // this is b/c the value of LP shares are ~double the value of the wavax they entitle owner to
-					),
-					totalSupplyOfStakingToken.raw
-				)
-			)
-		}
-
-		// get the USD value of staked wavax
-		// usdToken = wavax
-
-
 	} else {
-		var png
-		if (token0.equals(PNG[token0.chainId])) {
-			token = token1
-			png = token0
-		} else {
-			token = token0
-			png = token1
-		}
-
-		if (totalSupplyOfStakingToken && stakingTokenPair && avaxPngTokenPair) {
-			const oneToken = JSBI.BigInt(1000000000000000000)
-			const avaxPngRatio = JSBI.divide(JSBI.multiply(oneToken, avaxPngTokenPair.reserveOf(WAVAX[token1.chainId]).raw),
-				avaxPngTokenPair.reserveOf(png).raw)
-
-
-			const valueOfPngInAvax = JSBI.divide(JSBI.multiply(stakingTokenPair.reserveOf(png).raw, avaxPngRatio), oneToken)
-
-			valueOfTotalStakedAmountInWavax = new TokenAmount(WAVAX[token1.chainId],
-				JSBI.divide(
-					JSBI.multiply(
-						JSBI.multiply(stakingInfo.totalStakedAmount.raw, valueOfPngInAvax),
-						JSBI.BigInt(2) // this is b/c the value of LP shares are ~double the value of the wavax they entitle owner to
-					),
-					totalSupplyOfStakingToken.raw
-				)
-			)
-
-		}
-		// usdToken = png
+		token = token0.equals(PNG[token0.chainId]) ? token1 : token0
 	}
-
+	// let valueOfTotalStakedAmountInUSDC: CurrencyAmount | undefined
 	// get the color of the token
-	backgroundColor = useColor(token)
-
+	let backgroundColor = useColor(token)
+	
+	// let usdToken: Token
 	// const USDPrice = useUSDCPrice(usdToken)
 	// valueOfTotalStakedAmountInUSDC =
 	// valueOfTotalStakedAmountInWavax && USDPrice?.quote(valueOfTotalStakedAmountInWavax)
-	let weeklyRewardPerAvax: Fraction | undefined
 	let weeklyRewardAmount = stakingInfo.totalRewardRate.multiply(JSBI.BigInt(60 * 60 * 24 * 7))
-
-	if (valueOfTotalStakedAmountInWavax !== undefined)
-	{
-		weeklyRewardPerAvax = weeklyRewardAmount.divide(valueOfTotalStakedAmountInWavax)
-	}
+	const weeklyRewardPerAvax = weeklyRewardAmount.divide(stakingInfo.totalStakedInWavax)
 
 	return (
 		<Wrapper showBackground={isStaking} bgColor={backgroundColor}>
@@ -183,7 +120,7 @@ export default function PoolCard({ stakingInfo }: { stakingInfo: StakingInfo }) 
 				<RowBetween>
 					<TYPE.white> Total deposited</TYPE.white>
 					<TYPE.white>
-						{`${valueOfTotalStakedAmountInWavax?.toSignificant(4, { groupSeparator: ',' }) ?? '-'} AVAX`}
+						{`${stakingInfo.totalStakedInWavax.toSignificant(4, { groupSeparator: ',' }) ?? '-'} AVAX`}
 						{/* {valueOfTotalStakedAmountInUSDC
 							? `$${valueOfTotalStakedAmountInUSDC.toFixed(0, { groupSeparator: ',' })}`
 							: `${valueOfTotalStakedAmountInWavax?.toSignificant(4, { groupSeparator: ',' }) ?? '-'} AVAX`} */}
@@ -191,11 +128,11 @@ export default function PoolCard({ stakingInfo }: { stakingInfo: StakingInfo }) 
 				</RowBetween>
 				<RowBetween>
 					<TYPE.white> Pool rate </TYPE.white>
-					<TYPE.white>{`${weeklyRewardAmount?.toFixed(0, { groupSeparator: ',' })} PNG / week`}</TYPE.white>
+					<TYPE.white>{`${weeklyRewardAmount.toFixed(0, { groupSeparator: ',' })} PNG / week`}</TYPE.white>
 				</RowBetween>
 				<RowBetween>
 					<TYPE.white> Current reward </TYPE.white>
-					<TYPE.white>{`${weeklyRewardPerAvax?.toFixed(4, {groupSeparator: ','}) ?? '-'} PNG / Week per AVAX`}</TYPE.white>
+					<TYPE.white>{`${weeklyRewardPerAvax.toFixed(4, {groupSeparator: ','}) ?? '-'} PNG / Week per AVAX`}</TYPE.white>
 				</RowBetween>
 			</StatContainer>
 

--- a/src/pages/Earn/index.tsx
+++ b/src/pages/Earn/index.tsx
@@ -8,6 +8,8 @@ import { RowBetween } from '../../components/Row'
 import { CardSection, DataCard, CardNoise, CardBGImage } from '../../components/earn/styled'
 import Loader from '../../components/Loader'
 import { useActiveWeb3React } from '../../hooks'
+import { JSBI } from '@pangolindex/sdk'
+
 
 const PageWrapper = styled(AutoColumn)`
    max-width: 640px;
@@ -84,11 +86,34 @@ export default function Earn() {
 					) : !stakingRewardsExist ? (
 						'No active rewards'
 					) : (
-								stakingInfos?.map(stakingInfo => {
-									// need to sort by added liquidity here
+						stakingInfos?.sort(
+								function(info_a, info_b) { 
+									// greater stake in avax comes first
+									return info_a.totalStakedInWavax?.greaterThan(info_b.totalStakedInWavax ?? JSBI.BigInt(0)) ? -1 : 1
+								}
+							).sort(
+								function(info_a, info_b) {
+									if (info_a.stakedAmount.greaterThan(JSBI.BigInt(0))) {
+										if (info_b.stakedAmount.greaterThan(JSBI.BigInt(0)))
+											// both are being staked, so we keep the previous sorting
+											return 0
+										else
+											// the second is actually not at stake, so we should bring the first up
+											return -1
+									} else {
+										if (info_b.stakedAmount.greaterThan(JSBI.BigInt(0)))
+											// first is not being staked, but second is, so we should bring the first down
+											return 1
+										else
+											// none are being staked, let's keep the  previous sorting
+											return 0
+									}
+							}).map(
+								stakingInfo => {
 									return <PoolCard key={stakingInfo.stakingRewardAddress} stakingInfo={stakingInfo} />
-								})
-							)}
+								}
+							)
+					)}
 				</PoolSection>
 			</AutoColumn>
 		</PageWrapper>


### PR DESCRIPTION
This change was a bit harder, and more controversal, so here are the changes:

1. Moved the total stake in avax from the PoolCard to the StakingInfo, there are some reasons why this change seemed like a good idea, first one is performance, we were already taking care of calculating a lot of things in StakingInfo, and by moving it to there it meant we could make better use of memoization, it also helped with next change
2. Sorting the PoolCard listing in the earn page by your own stake, and then, by total stake of avax of the pool, this way we get a nice ordered view
3. Cleanup of the PoolCard, now it's looking way better there, it's always a good idea to have pure views whenever possible

I'm not super familiar with the project, so any feedback is welcome, I'm not 100% sure if my changes are aligned with the project goal, so this could be a great place to get some direction...

Here is an example of the new sorting:
![image](https://user-images.githubusercontent.com/1124468/109873138-42d92400-7c65-11eb-9429-304c56873189.png)
