### PR TITLE
Accurately label the "staked" value of a pair

### DIFF
--- a/src/pages/Earn/Manage.tsx
+++ b/src/pages/Earn/Manage.tsx
@@ -227,7 +227,7 @@ export default function Manage({
 			<DataRow style={{ gap: '24px' }}>
 				<PoolData>
 					<AutoColumn gap="sm">
-						<TYPE.body style={{ margin: 0 }}>Total deposits</TYPE.body>
+						<TYPE.body style={{ margin: 0 }}>Total Staked</TYPE.body>
 						<TYPE.body fontSize={24} fontWeight={500}>
 							{`${valueOfTotalStakedAmountInWavax?.toSignificant(4, { groupSeparator: ',' }) ?? '-'} AVAX`}
 							{/* {valueOfTotalStakedAmountInUSDC


### PR DESCRIPTION
There are two AVAX values being calculated:

1) Participating Pools Page:
    * Value of total pair reserves in terms of AVAX
2) Manage Liquidity Page:
    * Value of staked PGL in terms of AVAX

These should be accurately described to not confuse users who would assume them to have the same value