### PR TITLE
Add button to allow easy switching to the Avalanche Network

### DIFF
--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -8,12 +8,13 @@ import styled from 'styled-components'
 import MetamaskIcon from '../../assets/images/metamask.png'
 import { ReactComponent as Close } from '../../assets/images/x.svg'
 import { injected } from '../../connectors'
-import { LANDING_PAGE, SUPPORTED_WALLETS } from '../../constants'
+import { LANDING_PAGE, SUPPORTED_WALLETS, AVALANCHE_CHAIN_PARAMS } from '../../constants'
 import usePrevious from '../../hooks/usePrevious'
 import { ApplicationModal } from '../../state/application/actions'
 import { useModalOpen, useWalletModalToggle } from '../../state/application/hooks'
 import { ExternalLink } from '../../theme'
 import AccountDetails from '../AccountDetails'
+import { ButtonLight } from '../../components/Button'
 
 import Modal from '../Modal'
 import Option from './Option'
@@ -278,7 +279,21 @@ export default function WalletModal({
     })
   }
 
+  function addAvalancheNetwork() {
+    injected.getProvider().then(provider => {
+      provider
+        .request({
+          method: 'wallet_addEthereumChain',
+          params: [AVALANCHE_CHAIN_PARAMS]
+        })
+        .catch((error: any) => {
+          console.log(error)
+        })
+    })
+  }
+
   function getModalContent() {
+    const isMetamask = window.ethereum && window.ethereum.isMetaMask
     if (error) {
       return (
         <UpperSection>
@@ -288,7 +303,10 @@ export default function WalletModal({
           <HeaderRow>{error instanceof UnsupportedChainIdError ? 'Wrong Network' : 'Error connecting'}</HeaderRow>
           <ContentWrapper>
             {error instanceof UnsupportedChainIdError ? (
-              <h5>Please connect to the appropriate Avalanche network.</h5>
+              <>
+                <h5>Please connect to the appropriate Avalanche network.</h5>
+                {isMetamask && <ButtonLight onClick={addAvalancheNetwork}>Switch to Avalanche Chain</ButtonLight>}
+              </>
             ) : (
               'Error connecting. Try refreshing the page.'
             )}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -148,7 +148,7 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
 export const NetworkContextName = 'NETWORK'
 
 export const AVALANCHE_CHAIN_PARAMS = {
-  chainId: '0x' + parseInt('0xa86a').toString(16), // A 0x-prefixed hexadecimal string
+  chainId: '0xa86a', // A 0x-prefixed hexadecimal chainId
   chainName: 'Avalanche Mainnet C-Chain',
   nativeCurrency: {
     name: 'Avalanche',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -147,6 +147,18 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
 
 export const NetworkContextName = 'NETWORK'
 
+export const AVALANCHE_CHAIN_PARAMS = {
+  chainId: '0x' + parseInt('0xa86a').toString(16), // A 0x-prefixed hexadecimal string
+  chainName: 'Avalanche Mainnet C-Chain',
+  nativeCurrency: {
+    name: 'Avalanche',
+    symbol: 'AVAX',
+    decimals: 18
+  },
+  rpcUrls: ['https://api.avax.network/ext/bc/C/rpc'],
+  blockExplorerUrls: ['https://cchain.explorer.avax.network/']
+}
+
 // default allowed slippage, in bips
 export const INITIAL_ALLOWED_SLIPPAGE = 50
 // 60 minutes, denominated in seconds


### PR DESCRIPTION
Allows MetaMask users to easily switch to the Avalanche chain by clicking a button.

![Screen Shot 2021-03-15 at 12 36 08 AM](https://user-images.githubusercontent.com/3360539/111105447-5e77e080-8529-11eb-82bc-ae3540223f10.png)

When a user does not have the Avalanche Network MetaMask will show a prompt to add the Network
![Screen Shot 2021-03-15 at 12 54 23 AM](https://user-images.githubusercontent.com/3360539/111105340-21135300-8529-11eb-9ee0-d0593e4b6d85.png)

When a user already has the Avalanche Network MetaMask will prompt to switch networks
![Screen Shot 2021-03-15 at 12 56 26 AM](https://user-images.githubusercontent.com/3360539/111105422-5029c480-8529-11eb-814a-838605d53deb.png)
