### PR TITLE
Whitelist available locales

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -16,6 +16,7 @@ i18next
     },
     fallbackLng: 'en',
     preload: ['en'],
+    whitelist: ['de', 'en', 'es-AR', 'es-US', 'it-IT', 'iw', 'ro', 'ru', 'vi', 'zh-CN', 'zh-TW'],
     keySeparator: false,
     interpolation: { escapeValue: false }
   })


### PR DESCRIPTION
Sometimes the interface will freeze waiting for a locale such as `en-US` to load which doesn't exist. Pangolin appears broken/down for 30 seconds or until the request times out and i18next falls back to `en`

This avoids the potential timeout and will immediately revert to `en` if a requested locale doesn't exist