### PR TITLE
Defaults to the Top15 tokenlist

### DIFF
--- a/src/constants/lists.ts
+++ b/src/constants/lists.ts
@@ -1,11 +1,13 @@
 // the Pangolin Default token list lives here
-export const DEFAULT_TOKEN_LIST_URL = 'https://raw.githubusercontent.com/pangolindex/tokenlists/main/aeb.tokenlist.json'
+export const AEB_TOKENLIST = 'https://raw.githubusercontent.com/pangolindex/tokenlists/main/aeb.tokenlist.json'
 export const TOP_15_TOKEN_List = 'https://raw.githubusercontent.com/pangolindex/tokenlists/main/top15.tokenlist.json'
 export const DEFI_TOKEN_LIST = 'https://raw.githubusercontent.com/pangolindex/tokenlists/main/defi.tokenlist.json'
 export const STABLECOIN_TOKEN_LIST = 'https://raw.githubusercontent.com/pangolindex/tokenlists/main/stablecoin.tokenlist.json'
+export const DEFAULT_TOKEN_LIST_URL = TOP_15_TOKEN_List
 
 export const DEFAULT_LIST_OF_LISTS: string[] = [
   TOP_15_TOKEN_List,
+  AEB_TOKENLIST,
   DEFAULT_TOKEN_LIST_URL,
   DEFI_TOKEN_LIST,
   STABLECOIN_TOKEN_LIST


### PR DESCRIPTION
Change the default tokenlist from the aeb list to the top15 list.

Users that have already used the app will  not be affected as their preference is saved in local browser storage