### PR TITLE
Fix Claim Modal

### DIFF
--- a/src/components/Header/PngBalanceContent.tsx
+++ b/src/components/Header/PngBalanceContent.tsx
@@ -100,7 +100,7 @@ export default function PngBalanceContent({ setShowPngBalanceModal }: { setShowP
 									<TYPE.white color="white">
 										{pngToClaim?.toFixed(4, { groupSeparator: ',' })}{' '}
 										{pngToClaim && pngToClaim.greaterThan('0') && (
-											<StyledInternalLink onClick={() => setShowPngBalanceModal(false)} to="/png">
+											<StyledInternalLink onClick={() => setShowPngBalanceModal(false)} to="/png/1">
 												(claim)
 											</StyledInternalLink>
 										)}

--- a/src/state/stake/hooks.ts
+++ b/src/state/stake/hooks.ts
@@ -433,10 +433,20 @@ export function useStakingInfo(version: number, pairToFilterBy?: Pair | null): S
 export function useTotalPngEarned(): TokenAmount | undefined {
 	const { chainId } = useActiveWeb3React()
 	const png = chainId ? PNG[chainId] : undefined
-	const stakingInfo1 = useStakingInfo(0)
-	const stakingInfo2 = useStakingInfo(1)
+	const stakingInfo0 = useStakingInfo(0)
+	const stakingInfo1 = useStakingInfo(1)
 
-	let earned1 = useMemo(() => {
+	const earned0 = useMemo(() => {
+		if (!png) return undefined
+		return (
+			stakingInfo0?.reduce(
+				(accumulator, stakingInfo) => accumulator.add(stakingInfo.earnedAmount),
+				new TokenAmount(png, '0')
+			) ?? new TokenAmount(png, '0')
+		)
+	}, [stakingInfo0, png])
+
+	const earned1 = useMemo(() => {
 		if (!png) return undefined
 		return (
 			stakingInfo1?.reduce(
@@ -446,18 +456,7 @@ export function useTotalPngEarned(): TokenAmount | undefined {
 		)
 	}, [stakingInfo1, png])
 
-	let earned2 = useMemo(() => {
-		if (!png) return undefined
-		return (
-			stakingInfo2?.reduce(
-				(accumulator, stakingInfo) => accumulator.add(stakingInfo.earnedAmount),
-				new TokenAmount(png, '0')
-			) ?? new TokenAmount(png, '0')
-		)
-	}, [stakingInfo2, png])
-
-	let total = earned1 ? (earned2 ? earned1.add(earned2) : earned1) : (earned2 ? earned2 : undefined)
-	return total
+	return earned0 ? (earned1 ? earned0.add(earned1) : earned0) : (earned1 ? earned1 : undefined)
 }
 
 // based on typed value


### PR DESCRIPTION
The unclaimed PNG can be from old and new staking, but we cannot easily determine from which pools this balance includes. Defaulting to the new PNG page since this will be correct for the vast amount of users.