### PR TITLE
Correcting "PNG A/B Burned" to "PGL A/B Burned"

### DIFF
--- a/src/pages/RemoveLiquidity/index.tsx
+++ b/src/pages/RemoveLiquidity/index.tsx
@@ -381,7 +381,7 @@ export default function RemoveLiquidity({
       <>
         <RowBetween>
           <Text color={theme.text2} fontWeight={500} fontSize={16}>
-            {'PNG ' + currencyA?.symbol + '/' + currencyB?.symbol} Burned
+            {'PGL ' + currencyA?.symbol + '/' + currencyB?.symbol} Burned
           </Text>
           <RowFixed>
             <DoubleCurrencyLogo currency0={currencyA} currency1={currencyB} margin={true} />


### PR DESCRIPTION
Currently, when a user remove liquidity from a pool, the interface says the user is burning PNG instead of PGL.