### PR TITLE
Update i18n.ts

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -16,7 +16,7 @@ i18next
     },
     fallbackLng: 'en',
     preload: ['en'],
-    whitelist: ['de', 'en', 'es-AR', 'es-US', 'it-IT', 'iw', 'ro', 'ru', 'vi', 'zh-CN', 'zh-TW'],
+    whitelist: ['en', 'de', 'es-AR', 'es-US', 'it-IT', 'iw', 'ro', 'ru', 'vi', 'zh-CN', 'zh-TW'],
     keySeparator: false,
     interpolation: { escapeValue: false }
   })


### PR DESCRIPTION
It seems like i18next will take the first language in the whitelist when no appropriate locale is detected, so that would make German the default choice instead of English.
This puts English first.
(Note this is a temporary fix until we merge the localization PR which should fix this)