### PR TITLE
add HUSKY for PNG rewards

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -191,6 +191,26 @@ export const HUSKY: { [chainId in ChainId]: Token } = {
   [ChainId.AVALANCHE]: new Token(ChainId.AVALANCHE, '0x65378b697853568dA9ff8EaB60C13E1Ee9f4a654', 18, 'HUSKY', 'Husky')
 }
 
+export const USDCe: { [chainId in ChainId]: Token } = {
+  [ChainId.FUJI]: new Token(ChainId.FUJI, ZERO_ADDRESS, 6, 'USDC.e', 'USD Coin'),
+  [ChainId.AVALANCHE]: new Token(ChainId.AVALANCHE, '0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664', 6, 'USDC.e', 'USD Coin')
+}
+
+export const LYD: { [chainId in ChainId]: Token } = {
+  [ChainId.FUJI]: new Token(ChainId.FUJI, ZERO_ADDRESS, 18, 'LYD', 'LydiaFinance Token'),
+  [ChainId.AVALANCHE]: new Token(ChainId.AVALANCHE, '0x4C9B4E1AC6F24CdE3660D5E4Ef1eBF77C710C084', 18, 'LYD', 'LydiaFinance Token')
+}
+
+export const TUSD: { [chainId in ChainId]: Token } = {
+  [ChainId.FUJI]: new Token(ChainId.FUJI, ZERO_ADDRESS, 18, 'TUSD', 'TrueUSD'),
+  [ChainId.AVALANCHE]: new Token(ChainId.AVALANCHE, '0x1C20E891Bab6b1727d14Da358FAe2984Ed9B59EB', 18, 'TUSD', 'TrueUSD')
+}
+
+export const GAJ: { [chainId in ChainId]: Token } = {
+  [ChainId.FUJI]: new Token(ChainId.FUJI, ZERO_ADDRESS, 18, 'GAJ', 'PolyGaj Token'),
+  [ChainId.AVALANCHE]: new Token(ChainId.AVALANCHE, '0x595c8481c48894771CE8FaDE54ac6Bf59093F9E8', 18, 'GAJ', 'PolyGaj Token')
+}
+
 export const AIRDROP_ADDRESS: { [chainId in ChainId]?: string } = {
   [ChainId.FUJI]: ZERO_ADDRESS,
   [ChainId.AVALANCHE]: '0x0C58C2041da4CfCcF5818Bbe3b66DBC23B3902d9'

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -186,6 +186,11 @@ export const WALBT: { [chainId in ChainId]: Token } = {
   [ChainId.AVALANCHE]: new Token(ChainId.AVALANCHE, '0x9E037dE681CaFA6E661e6108eD9c2bd1AA567Ecd', 18, 'WALBT', 'Wrapped AllianceBlock Token')
 }
 
+export const HUSKY: { [chainId in ChainId]: Token } = {
+  [ChainId.FUJI]: new Token(ChainId.FUJI, ZERO_ADDRESS, 18, 'HUSKY', 'Husky'),
+  [ChainId.AVALANCHE]: new Token(ChainId.AVALANCHE, '0x65378b697853568dA9ff8EaB60C13E1Ee9f4a654', 18, 'HUSKY', 'Husky')
+}
+
 export const AIRDROP_ADDRESS: { [chainId in ChainId]?: string } = {
   [ChainId.FUJI]: ZERO_ADDRESS,
   [ChainId.AVALANCHE]: '0x0C58C2041da4CfCcF5818Bbe3b66DBC23B3902d9'

--- a/src/state/stake/hooks.ts
+++ b/src/state/stake/hooks.ts
@@ -33,6 +33,7 @@ import {
   DYP,
   QI,
   WALBT,
+  HUSKY,
 } from '../../constants'
 import { STAKING_REWARDS_INTERFACE } from '../../constants/abis/staking-rewards'
 import { PairState, usePair, usePairs } from '../../data/Reserves'
@@ -317,6 +318,11 @@ const STAKING: {
     stakingRewardAddress: '0xa296F9474e77aE21f90afb50713F44Cc6916FbB2',
     version: 1
   },
+  WAVAX_HUSKY_V1: {
+    tokens: [WAVAX[ChainId.AVALANCHE], HUSKY[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
+    version: 1
+  },
 
   PNG_ETH_V1: {
     tokens: [PNG[ChainId.AVALANCHE], ETH[ChainId.AVALANCHE]],
@@ -471,6 +477,11 @@ const STAKING: {
   PNG_WALBT_V1: {
     tokens: [PNG[ChainId.AVALANCHE], WALBT[ChainId.AVALANCHE]],
     stakingRewardAddress: '0x393fe4bc29AfbB3786D99f043933c49097449fA1',
+    version: 1
+  },
+  PNG_HUSKY_V1: {
+    tokens: [PNG[ChainId.AVALANCHE], HUSKY[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
     version: 1
   },
 }

--- a/src/state/stake/hooks.ts
+++ b/src/state/stake/hooks.ts
@@ -34,6 +34,10 @@ import {
   QI,
   WALBT,
   HUSKY,
+  USDCe,
+  LYD,
+  TUSD,
+  GAJ,
 } from '../../constants'
 import { STAKING_REWARDS_INTERFACE } from '../../constants/abis/staking-rewards'
 import { PairState, usePair, usePairs } from '../../data/Reserves'
@@ -323,6 +327,26 @@ const STAKING: {
     stakingRewardAddress: '0x0000000000000000000000000000000000000000',
     version: 1
   },
+  WAVAX_USDCe_V1: {
+    tokens: [WAVAX[ChainId.AVALANCHE], USDCe[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
+    version: 1
+  },
+  WAVAX_LYD_V1: {
+    tokens: [WAVAX[ChainId.AVALANCHE], LYD[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
+    version: 1
+  },
+  WAVAX_TUSD_V1: {
+    tokens: [WAVAX[ChainId.AVALANCHE], TUSD[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
+    version: 1
+  },
+  WAVAX_GAJ_V1: {
+    tokens: [WAVAX[ChainId.AVALANCHE], GAJ[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
+    version: 1
+  },
 
   PNG_ETH_V1: {
     tokens: [PNG[ChainId.AVALANCHE], ETH[ChainId.AVALANCHE]],
@@ -481,6 +505,26 @@ const STAKING: {
   },
   PNG_HUSKY_V1: {
     tokens: [PNG[ChainId.AVALANCHE], HUSKY[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
+    version: 1
+  },
+  PNG_USDCe_V1: {
+    tokens: [PNG[ChainId.AVALANCHE], USDCe[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
+    version: 1
+  },
+  PNG_LYD_V1: {
+    tokens: [PNG[ChainId.AVALANCHE], LYD[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
+    version: 1
+  },
+  PNG_TUSD_V1: {
+    tokens: [PNG[ChainId.AVALANCHE], TUSD[ChainId.AVALANCHE]],
+    stakingRewardAddress: '0x0000000000000000000000000000000000000000',
+    version: 1
+  },
+  PNG_GAJ_V1: {
+    tokens: [PNG[ChainId.AVALANCHE], GAJ[ChainId.AVALANCHE]],
     stakingRewardAddress: '0x0000000000000000000000000000000000000000',
     version: 1
   },


### PR DESCRIPTION
Husky is the merchandise token of husky.space, and it satisfies the
Universal Guidelines for PNG rewards requirements:

Requirements:
* $150k+ token liquidity on Pangolin
* Avalanche native token
* 2036 holders on Avalanche and 594 holders on BSC

Extras:
* +$15M market cap
* +$8.6M volume in last 24 hours