### PR TITLE
Protect the Pangolin brand by removing bad links and unclear text

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -390,7 +390,7 @@
   },
   "buyPage": {
     "buyAvaxInfo": "Buy AVAX with fiat from our partner Wyre.",
-    "privacyInfo": "Pangolin does not store your purchase history or any personal data.",
+    "privacyInfo": "Note: Pangolin does not store your purchase history or any personal data.",
     "firstName": "First Name",
     "lastName": "Last Name",
     "email": "Email",

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -223,7 +223,7 @@ const StyledNavLink = styled(NavLink).attrs({
 
 const StyledExternalLink = styled(ExternalLink).attrs({
   activeClassName
-})<{ isActive?: boolean }>`
+}) <{ isActive?: boolean }>`
   ${({ theme }) => theme.flexRowNoWrap}
   align-items: left;
   border-radius: 3rem;
@@ -287,9 +287,7 @@ export default function Header() {
           <StyledNavLink id={`swap-nav-link`} to={'/swap'}>
             {t('header.swap')}
           </StyledNavLink>
-          <StyledNavLink id={`swap-nav-link`} to={'/buy'}>
-            {t('header.buy')}
-          </StyledNavLink>
+
           <StyledNavLink
             id={`pool-nav-link`}
             to={'/pool'}
@@ -319,6 +317,9 @@ export default function Header() {
           <StyledExternalLink id={`gov-nav-link`} href={'https://gov.pangolin.exchange'}>
             {t('header.forum')} <span style={{ fontSize: '11px' }}>↗</span>
           </StyledExternalLink>
+          <StyledNavLink id={`swap-nav-link`} to={'/buy'}>
+            {t('header.buy')}
+          </StyledNavLink>
         </HeaderLinks>
       </HeaderRow>
       <HeaderControls>

--- a/src/pages/Buy/index.tsx
+++ b/src/pages/Buy/index.tsx
@@ -1,18 +1,18 @@
 import AppBody from "../AppBody";
-import {Wrapper} from "../../components/swap/styleds";
-import React, {useState} from 'react'
-import {TYPE} from "../../theme";
-import PurchaseForm, {Data } from "../../components/PurchaseForm"
+import { Wrapper } from "../../components/swap/styleds";
+import React, { useState } from 'react'
+import { TYPE } from "../../theme";
+import PurchaseForm, { Data } from "../../components/PurchaseForm"
 import TextInput from "../../components/PurchaseForm/input"
-import {ButtonPrimary} from "../../components/Button";
-import {AutoColumn, ColumnCenter} from "../../components/Column";
-import {OutlineCard} from "../../components/Card";
+import { ButtonPrimary } from "../../components/Button";
+import { AutoColumn, ColumnCenter } from "../../components/Column";
+import { OutlineCard } from "../../components/Card";
 import FiatInputPanel from "../../components/FiatInputPanel";
 import { USD } from '../../constants/fiat'
-import {useQuoteRequest} from '../../state/wyre/hooks'
-import {useActiveWeb3React} from "../../hooks";
+import { useQuoteRequest } from '../../state/wyre/hooks'
+import { useActiveWeb3React } from "../../hooks";
 import Footer from "../../components/FiatInputPanel/Footer";
-import {redirectToWyre} from "./redirect";
+import { redirectToWyre } from "./redirect";
 import { useTranslation } from 'react-i18next'
 
 const emailPattern = /^[A-Za-z0-9][A-Za-z0-9._-]*@[A-za-z0-9.-]+\.[A-Za-z]{2,4}$/;
@@ -46,7 +46,8 @@ export default function Buy() {
   const { t } = useTranslation()
 
   const handleSubmit = (data: Data) => {
-    const formDataWithAmount = {...data,
+    const formDataWithAmount = {
+      ...data,
       amount: amount,
       sourceCurrency: fiat.symbol,
       dest: `avalanche:${account?.toLowerCase()}`
@@ -64,21 +65,24 @@ export default function Buy() {
       <AppBody>
         <Wrapper id="swap-page">
           <ColumnCenter>
-              <AutoColumn gap="10px">
-                <OutlineCard>
+            <AutoColumn gap="10px">
+              <OutlineCard>
+                <TYPE.mediumHeader color={'primaryText2'}>
+                  {t('buyPage.buyAvax')}<br />
+                </TYPE.mediumHeader>
                 <TYPE.link fontSize={14} fontWeight={500} color={'primaryText2'}>
-                  {t('buyPage.buyAvaxInfo')}<br/>
+                  {t('buyPage.buyAvaxInfo')}<br />
                   {t('buyPage.privacyInfo')}
                 </TYPE.link>
-                </OutlineCard>
-              </AutoColumn>
+              </OutlineCard>
+            </AutoColumn>
           </ColumnCenter>
           <p></p>
           <PurchaseForm onSubmit={handleSubmit}>
             <TextInput type="text" name="firstName" placeholder={t('buyPage.firstName')} validators={[minLengthValidator]} onError={setFieldError}></TextInput>
             <TextInput type="text" name="lastName" placeholder={t('buyPage.lastName')} validators={[minLengthValidator]} onError={setFieldError}></TextInput>
             <TextInput type="text" name="email" placeholder={t('buyPage.email')} validators={[emailValidator, minLengthValidator]} onError={setFieldError}></TextInput>
-            <FiatInputPanel fiat={fiat} value={amount} onUserInput={setAmount} onFiatSelect={setFiat} id="fiatPanel"/>
+            <FiatInputPanel fiat={fiat} value={amount} onUserInput={setAmount} onFiatSelect={setFiat} id="fiatPanel" />
             {formError ? <TYPE.error title={'Error'} error>An error occurred while submitting the data to Wyre</TYPE.error> : null}
             <ButtonPrimary type="submit" style={{ margin: '20px 0 0 0' }} disabled={!ableToBuy}>
               {t('buyPage.buyAvax')}
@@ -87,6 +91,6 @@ export default function Buy() {
 
         </Wrapper>
       </AppBody>
-      <Footer/>
+      <Footer />
     </>)
 }

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -43,7 +43,7 @@ import AppBody from '../AppBody'
 import { ClickableText } from '../Pool/styleds'
 import Loader from '../../components/Loader'
 import useENS from '../../hooks/useENS'
-import { Trans, useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { useIsSelectedAEBToken } from '../../state/lists/hooks'
 import { DeprecatedWarning } from '../../components/Warning'
 
@@ -57,15 +57,15 @@ const BottomText = styled.span`
   font-size: 18px;
 `
 
-const VeloxLink = styled.a`
+/* const VeloxLink = styled.a`
   color: #f25c23;
   text-decoration: none;
-`
+` */
 
-const MarginswapLink = styled.a`
-  color: #f25c23;
-  text-decoration: none;
-`
+// const MarginswapLink = styled.a`
+//   color: #f25c23;
+//   text-decoration: none;
+// `
 
 const WarningWrapper = styled.div`
   max-width: 420px;
@@ -133,13 +133,13 @@ export default function Swap() {
 
   const parsedAmounts = showWrap
     ? {
-        [Field.INPUT]: parsedAmount,
-        [Field.OUTPUT]: parsedAmount
-      }
+      [Field.INPUT]: parsedAmount,
+      [Field.OUTPUT]: parsedAmount
+    }
     : {
-        [Field.INPUT]: independentField === Field.INPUT ? parsedAmount : trade?.inputAmount,
-        [Field.OUTPUT]: independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmount
-      }
+      [Field.INPUT]: independentField === Field.INPUT ? parsedAmount : trade?.inputAmount,
+      [Field.OUTPUT]: independentField === Field.OUTPUT ? parsedAmount : trade?.outputAmount
+    }
 
   const { onSwitchTokens, onCurrencySelection, onUserInput, onChangeRecipient } = useSwapActionHandlers()
   const isValid = !swapInputError
@@ -225,8 +225,8 @@ export default function Swap() {
             recipient === null
               ? 'Swap w/o Send'
               : (recipientAddress ?? recipient) === account
-              ? 'Swap w/o Send + recipient'
-              : 'Swap w/ Send',
+                ? 'Swap w/o Send + recipient'
+                : 'Swap w/ Send',
           label: [trade?.inputAmount?.currency?.symbol, trade?.outputAmount?.currency?.symbol, Version.v2].join('/')
         })
       })
@@ -301,12 +301,12 @@ export default function Swap() {
       )}
 
       <TopText>
-        <Trans i18nKey="swapPage.velox">
-          Set a limit order on
+        {/*         <Trans i18nKey="swapPage.velox">
+                    Set a limit order on
           <VeloxLink href={'https://app.velox.global/'} target={'_blank'}>
             Velox
           </VeloxLink>
-        </Trans>
+        </Trans> */}
       </TopText>
 
       <AppBody>
@@ -426,8 +426,8 @@ export default function Swap() {
                   (wrapType === WrapType.WRAP
                     ? t('swapPage.wrap')
                     : wrapType === WrapType.UNWRAP
-                    ? t('swapPage.unwrap')
-                    : null)}
+                      ? t('swapPage.unwrap')
+                      : null)}
               </ButtonPrimary>
             ) : noRoute && userHasSpecifiedInputOutput ? (
               <GreyCard style={{ textAlign: 'center' }}>
@@ -503,8 +503,8 @@ export default function Swap() {
                   {swapInputError
                     ? swapInputError
                     : priceImpactSeverity > 3 && !isExpertMode
-                    ? t('swapPage.priceImpactHigh')
-                    : t('swapPage.swap') + `${priceImpactSeverity > 2 ? t('swapPage.anyway') : ''}`}
+                      ? t('swapPage.priceImpactHigh')
+                      : t('swapPage.swap') + `${priceImpactSeverity > 2 ? t('swapPage.anyway') : ''}`}
                 </Text>
               </ButtonError>
             )}
@@ -526,12 +526,7 @@ export default function Swap() {
       <AdvancedSwapDetailsDropdown trade={trade} />
 
       <BottomText>
-        <Trans i18nKey="swapPage.marginSwap">
-          Trade with leverage on
-          <MarginswapLink href={'https://app.marginswap.exchange/swap'} target={'_blank'}>
-            Marginswap
-          </MarginswapLink>
-        </Trans>
+
       </BottomText>
     </>
   )


### PR DESCRIPTION
Pangolin's brand as the most trusted defi platform is at risk because of recent update problems that this pull request goes part way in resolving.

The primary problem is that third party functions have been interleaved with trusted Pangolin features, and several of these new functions do not work and/or do not display properly and otherwise detract from the trustworthiness of Pangolin.

To wit:  
1) Velox switches the user context to Ethereum after taking exceedingly long time to load
2) MarginSwap although seemingly an interesting offering for PNG holders also loads by default into Ethereum, and I've verified with other users that the ui for switching network context does not always work properly.
3) The text linking to MarginSwap was misaligned.
4) The "Buy" feature is a 3rd party feature which should not figure in prominently in the user interface.   Users clicking on it are presented with curious form requiring KYC type information with an unclear result as to what happens when the user fills it out and clicks.  THIS KYC REQUEST DAMAGES THE PANGOLIN BRAND AND SHOULD NOT FIGURE PROMINENTLY IN THE USER INTERFACE.

This pull request removes or hides these brand-dangerous features and goes part way in putting some of them in a right-most navlink.   I strongly suggest that this PR once evaluated be implemented quickly so as to not hurt the Pangolin brand further.

Later we can discuss ways to get MarginSwap and Velox working better and to make the KYC buy feature less intimidating and less prominent.

Thank you

