### PR TITLE
Update block explorer with snowtrace

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -764,7 +764,7 @@ export const AVALANCHE_CHAIN_PARAMS = {
     decimals: 18
   },
   rpcUrls: ['https://api.avax.network/ext/bc/C/rpc'],
-  blockExplorerUrls: ['https://cchain.explorer.avax.network/']
+  blockExplorerUrls: ['https://snowtrace.io//']
 }
 
 // default allowed slippage, in bips


### PR DESCRIPTION
### Note
Today, a new tool joins the suite of Avalanche infrastructure with SnowTrace, an implementation of Etherscan custom-built for the Avalanche blockchain.

[SnowTrace](https://snowtrace.io/) replaces the existing [Avalanche C-Chain Explorer](https://cchain.explorer.avax.network) to deliver a more highly-performant, feature-filled experience for the global community of Avalanche developers and users.

### What's New

- Updated `blockExplorerUrls` from https://cchain.explorer.avax.network/ to https://snowtrace.io/ 
