### PR TITLE
Send 3085 requests to Coinbase Wallet

### DIFF
--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -7,7 +7,10 @@ declare module 'jazzicon' {
 declare module 'fortmatic'
 
 interface Window {
+  WalletLinkProvider?: any
+  walletLinkExtension?: any
   ethereum?: {
+    isCoinbaseWallet?: boolean
     isMetaMask?: true
     on?: (...args: any[]) => void
     removeListener?: (...args: any[]) => void


### PR DESCRIPTION
Automatically sends 3085 request to CB Wallet to switch networks after user successfully connects. CB wallet is idempotent in handling 3085 requests, so will ignore request if user is already successfully on avalanche network.