### PR TITLE
fix: update walletlink-connector to 6.2.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@web3-react/fortmatic-connector": "^6.0.9",
     "@web3-react/portis-connector": "^6.0.9",
     "@web3-react/walletconnect-connector": "^6.1.1",
-    "@web3-react/walletlink-connector": "^6.2.7",
+    "@web3-react/walletlink-connector": "^6.2.11",
     "ajv": "^6.12.3",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,14 +4083,14 @@
     "@web3-react/types" "^6.0.7"
     tiny-invariant "^1.0.6"
 
-"@web3-react/walletlink-connector@^6.2.7":
-  version "6.2.8"
-  resolved "https://registry.yarnpkg.com/@web3-react/walletlink-connector/-/walletlink-connector-6.2.8.tgz#aaf7f413229f58d8087a15e0d049bbcbe5e0bd49"
-  integrity sha512-pSGufPz5JntSUvy88XcOrn5VN3qmX+ZVQ2lXAeWWb7YS2wTlAStPghZbln8t1li7jr1NUJ0w/gMDVpAwjwq4ZA==
+"@web3-react/walletlink-connector@^6.2.11":
+  version "6.2.11"
+  resolved "https://registry.yarnpkg.com/@web3-react/walletlink-connector/-/walletlink-connector-6.2.11.tgz#5b7b8d1c882531f28909d2144c1712264fad12f4"
+  integrity sha512-S9uiugqS/Taw8FRllHMlsM1EIl8f0XTbNhBSUH3DeOkyc+nsnNuH6dJ15OUe52CPYMTkJhmBuCVUpAWyAJIXmg==
   dependencies:
     "@web3-react/abstract-connector" "^6.0.7"
     "@web3-react/types" "^6.0.7"
-    walletlink "^2.2.6"
+    walletlink "^2.4.6"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -19728,10 +19728,10 @@ walker@^1.0.7, walker@~1.0.5:
   dependencies:
     makeerror "1.0.12"
 
-walletlink@^2.2.6:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/walletlink/-/walletlink-2.2.8.tgz#79ef55162a9fb41341b8063b0a6194928cd5bd9c"
-  integrity sha512-aEHMz5CUxO53fhwLD3+kMgtAOMCCSBXfT+sZnS4LikI7F6SBQny669I0jt2Igd7wD9zVlsdEdUmnog7ounDwjQ==
+walletlink@^2.4.6:
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/walletlink/-/walletlink-2.4.6.tgz#efaa950c16447bf34e186495b55755b3d7157725"
+  integrity sha512-CtfyRa3Tc9yTRFIoE0P0rhiq57WB6/XnJ0Fyc3tmSR4yntFP29sqp+SCDOI0R9Ot20gAKaYb2w/nnmLRrhfiJQ==
   dependencies:
     "@metamask/safe-event-emitter" "2.0.0"
     bind-decorator "^1.0.11"


### PR DESCRIPTION
walletlink-connector 6.2.11 updates walletlink to 2.4.6.

Coinbase Wallet clients will update on Monday to support wallet_addEthereumChain requests for any network. We made a change on the clients that is not compatible with older versions of walletlink (anything before 2.4.5).

2.4.6 also includes a fix for a common connectivity issue walletlink/coinbase-wallet-sdk#277