### PR TITLE
Fixed news date

### DIFF
--- a/src/pages/Dashboard/News/index.tsx
+++ b/src/pages/Dashboard/News/index.tsx
@@ -94,7 +94,10 @@ export default function NewsWidget() {
                     </Scrollbars>
                   </NewsContent>
                   <NewsDate>
-                    {element?.updatedAt.toLocaleTimeString()}, {element?.updatedAt.toLocaleDateString()}
+                    {element?.updatedAt
+                      ? element?.updatedAt?.toLocaleTimeString()
+                      : element?.createdAt.toLocaleTimeString()}
+                    , {element.updatedAt ? element?.updatedAt?.toDateString() : element?.createdAt.toDateString()}
                   </NewsDate>
                 </div>
               ))}

--- a/src/state/news/hooks.ts
+++ b/src/state/news/hooks.ts
@@ -7,7 +7,7 @@ export interface News {
   title: string
   content: string
   createdAt: Date
-  updatedAt: Date
+  updatedAt: Date | null
 }
 
 // Get News in Pangolin Strapi api
@@ -33,8 +33,8 @@ export function useGetNews() {
         title: element?.title,
         content: element?.content,
         createdAt: new Date(element?.date_created),
-        updatedAt: new Date(element?.date_updated)
-      }
+        updatedAt: !element?.date_updated ? null : new Date(element?.date_updated)
+      } as News
     })
 
     return news


### PR DESCRIPTION
Some news show date incorrent as timestamp 0 e.g (0:00 1/1/1970)
(showing -4 because my timestamp is utc -4)
![image](https://user-images.githubusercontent.com/37405304/162731217-71f9df90-c0e9-4623-a5da-bfd3f15df7f5.png)
