### PR TITLE
Fix bug in 'your liquidy' is showing incorrect amount

### DIFF
--- a/src/pages/Beta/Pool/DetailModal/StatDetail/index.tsx
+++ b/src/pages/Beta/Pool/DetailModal/StatDetail/index.tsx
@@ -54,7 +54,7 @@ export default function StatDetail({ title, totalAmount, pair, pgl, currency0, c
           title={`Underlying ${currency0?.symbol}`}
           stat={`${
             token0Deposited
-              ? numeral(parseFloat(token0Deposited?.toSignificant(6)).toLocaleString()).format('0.00a')
+              ? numeral(parseFloat(token0Deposited?.toSignificant(6))).format('0.00a')
               : '-'
           }`}
           titlePosition="top"
@@ -67,7 +67,7 @@ export default function StatDetail({ title, totalAmount, pair, pgl, currency0, c
           title={`Underlying ${currency1?.symbol}`}
           stat={`${
             token1Deposited
-              ? numeral(parseFloat(token1Deposited?.toSignificant(6)).toLocaleString()).format('0.00a')
+              ? numeral(parseFloat(token1Deposited?.toSignificant(6))).format('0.00a')
               : '-'
           }`}
           titlePosition="top"


### PR DESCRIPTION
It was showing incorrect values of the token in browsers that use a comma to separate the decimals from the integer
for example:
in portuguese 500 = 500,00 but in the user interface it was showing 500.00k
![image](https://user-images.githubusercontent.com/37405304/164082651-e5278e11-1175-4b1e-b884-5c0e2977c1de.png)
