### PR TITLE
Fix "invalid pair" in import pool

### DIFF
--- a/src/pages/Beta/Pool/PoolImportModal/PoolImport/index.tsx
+++ b/src/pages/Beta/Pool/PoolImportModal/PoolImport/index.tsx
@@ -1,15 +1,16 @@
 import React, { useContext, useEffect } from 'react'
-import { Currency, JSBI, TokenAmount } from '@pangolindex/sdk'
+import { Currency, JSBI, TokenAmount, Token } from '@pangolindex/sdk'
 import { Box, Text, CurrencyLogo } from '@pangolindex/components'
 import { PoolImportWrapper, ArrowWrapper, CurrencySelectWrapper, LightCard, Dots } from './styleds'
 import { Plus, ChevronDown } from 'react-feather'
 import { ThemeContext } from 'styled-components'
 import { useTranslation } from 'react-i18next'
 import { PairState, usePair } from 'src/data/Reserves'
-import { useActiveWeb3React } from 'src/hooks'
+import { useActiveWeb3React, useChainId } from 'src/hooks'
 import { usePairAdder } from 'src/state/user/hooks'
 import { useTokenBalance } from 'src/state/wallet/hooks'
 import PositionCard from '../PositionCard'
+import { wrappedCurrency } from 'src/utils/wrappedCurrency'
 
 enum Fields {
   TOKEN0 = 0,
@@ -30,7 +31,23 @@ const PoolImport = ({ currency0, currency1, openTokenDrawer, setActiveField, onM
   const { t } = useTranslation()
   const theme = useContext(ThemeContext)
 
-  const [pairState, pair] = usePair(currency0 ?? undefined, currency1 ?? undefined)
+  const chainId = useChainId()
+
+  let unwrapcurrency0 = wrappedCurrency(currency0, chainId)
+  let unwrapcurrency1 = wrappedCurrency(currency1, chainId)
+
+  if (currency0 && !(currency0 instanceof Currency)) {
+    const _currency0 = currency0 as any
+    unwrapcurrency0 = new Token(chainId, _currency0.address, _currency0.decimals, _currency0.symbol, _currency0.name)
+  }
+
+  if (currency1 && !(currency1 instanceof Currency)) {
+    const _currency1 = currency1 as any
+    unwrapcurrency1 = new Token(chainId, _currency1.address, _currency1.decimals, _currency1.symbol, _currency1.name)
+  }
+
+  const [pairState, pair] = usePair(unwrapcurrency0, unwrapcurrency1)
+
   const addPair = usePairAdder()
   useEffect(() => {
     if (pair) {


### PR DESCRIPTION
`SelectTokenDrawer` from `@pangolin/components` returns invalid format for tokens causing the [wrappedCurrency](https://github.com/pangolindex/interface/blob/dev/src/utils/wrappedCurrency.ts#L3) function to return `undefined` causing the pair to be invalid in the [usePairs](https://github.com/pangolindex/interface/blob/dev/src/data/Reserves.ts#L19) function
![image](https://user-images.githubusercontent.com/37405304/167221323-0ca05cc3-f042-4f69-a57b-c7bff8c4d2fd.png)
**Fixed problem**
![image](https://user-images.githubusercontent.com/37405304/167221033-9c83cadc-b8d1-4aa6-8a01-3d82ace8ac6e.png)
