### PR TITLE
Added SwapType into SwapUI

### DIFF
--- a/src/pages/Beta/Swap/index.tsx
+++ b/src/pages/Beta/Swap/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { PageWrapper, GridContainer, TopContainer, StatsWrapper } from './styleds'
-import { MyPortfolio, SwapWidget, WatchList } from '@pangolindex/components'
+import { MyPortfolio, SwapWidget, WatchList, SwapTypes } from '@pangolindex/components'
 import PairInfo from './PairInfo'
 import LimitOrderList from './LimitOrderList'
 import { useChainId } from 'src/hooks'
@@ -8,7 +8,6 @@ import { CHAINS } from '@pangolindex/sdk'
 import { isEvmChain } from 'src/utils'
 import ComingSoon from 'src/components/Beta/ComingSoon'
 import { useGelatoLimitOrdersHook } from 'src/state/swap/multiChainsHooks'
-import { SwapTypes } from '@pangolindex/components'
 
 const SwapUI = () => {
   const chainId = useChainId()

--- a/src/pages/Beta/Swap/index.tsx
+++ b/src/pages/Beta/Swap/index.tsx
@@ -14,7 +14,7 @@ const SwapUI = () => {
   const useGelatoLimitOrders = useGelatoLimitOrdersHook[chainId]
   const { allOrders } = useGelatoLimitOrders()
   const [swapType, onSwapTypeChange] = useState(SwapTypes.MARKET)
-  const isLimitOrders = (allOrders || []).length > 0
+  const isLimitOrders = (allOrders || []).length > 0 && swapType === SwapTypes.LIMIT
   return (
     <PageWrapper>
       <TopContainer>
@@ -24,7 +24,7 @@ const SwapUI = () => {
 
       {CHAINS[chainId]?.mainnet && isEvmChain(chainId) && (
         <GridContainer isLimitOrders={isLimitOrders}>
-          {isLimitOrders && swapType == SwapTypes.LIMIT && <LimitOrderList />}
+          {isLimitOrders && <LimitOrderList />}
           <MyPortfolio />
           <WatchList coinChartVisible={!isLimitOrders} />
         </GridContainer>

--- a/src/pages/Beta/Swap/index.tsx
+++ b/src/pages/Beta/Swap/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { PageWrapper, GridContainer, TopContainer, StatsWrapper } from './styleds'
 import { MyPortfolio, SwapWidget, WatchList } from '@pangolindex/components'
 import PairInfo from './PairInfo'
@@ -8,23 +8,24 @@ import { CHAINS } from '@pangolindex/sdk'
 import { isEvmChain } from 'src/utils'
 import ComingSoon from 'src/components/Beta/ComingSoon'
 import { useGelatoLimitOrdersHook } from 'src/state/swap/multiChainsHooks'
+import { SwapTypes } from '@pangolindex/components'
 
 const SwapUI = () => {
   const chainId = useChainId()
   const useGelatoLimitOrders = useGelatoLimitOrdersHook[chainId]
   const { allOrders } = useGelatoLimitOrders()
-
+  const [swapType, onSwapTypeChange] = useState(SwapTypes.MARKET)
   const isLimitOrders = (allOrders || []).length > 0
   return (
     <PageWrapper>
       <TopContainer>
         <StatsWrapper>{isEvmChain(chainId) ? <PairInfo /> : <ComingSoon />}</StatsWrapper>
-        <SwapWidget isLimitOrderVisible={CHAINS[chainId]?.mainnet} />
+        <SwapWidget onSwapTypeChange={onSwapTypeChange} isLimitOrderVisible={CHAINS[chainId]?.mainnet} />
       </TopContainer>
 
       {CHAINS[chainId]?.mainnet && isEvmChain(chainId) && (
         <GridContainer isLimitOrders={isLimitOrders}>
-          {isLimitOrders && <LimitOrderList />}
+          {isLimitOrders && swapType == SwapTypes.LIMIT && <LimitOrderList />}
           <MyPortfolio />
           <WatchList coinChartVisible={!isLimitOrders} />
         </GridContainer>


### PR DESCRIPTION
The Limit section just is shown when the user selects the Limit option. Also, users can be able to reach SwapType ('Market' or 'Limit') in SwapUI via "onSwapTypeChange". This is an optional callback. 

It requires "pangolinIndex/Component" repository developments.

depends on https://github.com/pangolindex/components/pull/102

https://app.clickup.com/t/3buhjpx