### PR TITLE
fix: evmos unaudited warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@ethersproject/wallet": "5.6.2",
     "@gnosis.pm/safe-apps-web3-react": "0.6.8",
     "@metamask/jazzicon": "2.0.0",
-    "@pangolindex/components": "7.1.4-internal.3609196",
+    "@pangolindex/components": "7.1.5-rc.1",
     "@pangolindex/exchange-contracts": "2.1.7",
     "@pangolindex/governance": "1.2.0",
     "@pangolindex/sdk": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@ethersproject/wallet": "5.6.2",
     "@gnosis.pm/safe-apps-web3-react": "0.6.8",
     "@metamask/jazzicon": "2.0.0",
-    "@pangolindex/components": "7.1.5-rc.0",
+    "@pangolindex/components": "7.1.4-internal.3609196",
     "@pangolindex/exchange-contracts": "2.1.7",
     "@pangolindex/governance": "1.2.0",
     "@pangolindex/sdk": "5.1.1",

--- a/src/layout/Sidebar/MenuLinks.tsx
+++ b/src/layout/Sidebar/MenuLinks.tsx
@@ -42,13 +42,32 @@ export interface LinkProps {
   childrens?: Array<LinkProps>
 }
 
+// Child MenuItem Interface
+interface IChildMenuItem {
+  link: string
+  icon: any
+  title: string
+  id: CHILD_MENU_TYPES
+  isActive: boolean
+}
+
+// Base level MenuItem Interface
+interface IMenuItem {
+  link: MENU_LINK | string
+  icon: any
+  title: string
+  id: string
+  isActive: boolean
+  childrens?: IChildMenuItem[]
+}
+
 export const MenuLinks: React.FC<Props> = ({ collapsed = false, onClick }) => {
   const { t } = useTranslation()
   const chainId = useChainId()
 
   const location: any = useLocation()
 
-  let mainLinks = [
+  let mainLinks: IMenuItem[] = [
     {
       link: MENU_LINK.dashboard,
       icon: Dashboard,
@@ -74,21 +93,21 @@ export const MenuLinks: React.FC<Props> = ({ collapsed = false, onClick }) => {
           link: `${MENU_LINK.buy}/${BUY_MENU_LINK.coinbasePay}`,
           icon: CoinbasePay,
           title: `Coinbase Pay`,
-          id: `${BUY_MENU_LINK.coinbasePay}`,
+          id: BUY_MENU_LINK.coinbasePay,
           isActive: location?.pathname?.startsWith(`${MENU_LINK.buy}/${BUY_MENU_LINK.coinbasePay}`)
         },
         {
           link: `${MENU_LINK.buy}/${BUY_MENU_LINK.moonpay}`,
           icon: MoonPay,
           title: 'Moonpay',
-          id: `${BUY_MENU_LINK.moonpay}`,
+          id: BUY_MENU_LINK.moonpay,
           isActive: location?.pathname?.startsWith(`${MENU_LINK.buy}/${BUY_MENU_LINK.moonpay}`)
         },
         {
           link: `${MENU_LINK.buy}/${BUY_MENU_LINK.c14}`,
           icon: C14,
           title: 'C14',
-          id: `${BUY_MENU_LINK.c14}`,
+          id: BUY_MENU_LINK.c14,
           isActive: location?.pathname?.startsWith(`${MENU_LINK.buy}/${BUY_MENU_LINK.c14}`)
         }
       ]
@@ -104,14 +123,14 @@ export const MenuLinks: React.FC<Props> = ({ collapsed = false, onClick }) => {
           link: `${MENU_LINK.pool}/${POOL_MENU_LINK.standard}`,
           icon: Pool,
           title: 'Standard',
-          id: `${POOL_MENU_LINK.standard}`,
+          id: POOL_MENU_LINK.standard,
           isActive: location?.pathname?.startsWith(`${MENU_LINK.pool}/${POOL_MENU_LINK.standard}`)
         },
         {
           link: `${MENU_LINK.pool}/${POOL_MENU_LINK.elixir}`,
           icon: Pool,
           title: 'Elixir',
-          id: `${POOL_MENU_LINK.elixir}`,
+          id: POOL_MENU_LINK.elixir,
           isActive: location?.pathname?.startsWith(`${MENU_LINK.pool}/${POOL_MENU_LINK.elixir}`)
         }
       ]
@@ -157,7 +176,7 @@ export const MenuLinks: React.FC<Props> = ({ collapsed = false, onClick }) => {
     .map(link => {
       if (link.childrens) {
         link.childrens = link.childrens.filter(
-          childLink => !shouldHideChildItem(chainId, link.link as MENU_LINK, childLink.link as CHILD_MENU_TYPES)
+          childLink => !shouldHideChildItem(chainId, link.link as MENU_LINK, childLink.id)
         )
       }
       return link

--- a/src/pages/Beta/Pool/index.tsx
+++ b/src/pages/Beta/Pool/index.tsx
@@ -5,7 +5,6 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { MENU_LINK, POOL_MENU_LINK } from 'src/constants'
 import { useChainId } from 'src/hooks'
 import { shouldHideChildItem } from 'src/utils'
-import { isMobile } from 'react-device-detect'
 import { AlertTriangle } from 'react-feather'
 export type PoolProps = Record<'type', POOL_MENU_LINK>
 
@@ -24,13 +23,7 @@ const PhishAlert = styled.div`
 const Alert = () => {
   const { t } = useTranslation()
 
-  return isMobile ? (
-    <PhishAlert>
-      <div style={{ display: 'flex', alignItems: 'center' }}>
-        <AlertTriangle style={{ marginRight: 6 }} size={12} /> {t('elixir.auditWarning')}
-      </div>
-    </PhishAlert>
-  ) : (
+  return (
     <PhishAlert>
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <AlertTriangle style={{ marginRight: 6 }} size={12} /> {t('elixir.auditWarning')}

--- a/src/pages/Beta/Pool/index.tsx
+++ b/src/pages/Beta/Pool/index.tsx
@@ -1,18 +1,66 @@
-import React from 'react'
-import { Elixir, PoolsUI } from '@pangolindex/components'
-import { useParams } from 'react-router-dom'
-import { POOL_MENU_LINK } from 'src/constants'
+import React, { useEffect } from 'react'
+import styled from 'styled-components'
+import { Elixir, PoolsUI, useTranslation } from '@pangolindex/components'
+import { useNavigate, useParams } from 'react-router-dom'
+import { MENU_LINK, POOL_MENU_LINK } from 'src/constants'
+import { useChainId } from 'src/hooks'
+import { shouldHideChildItem } from 'src/utils'
+import { isMobile } from 'react-device-detect'
+import { AlertTriangle } from 'react-feather'
 export type PoolProps = Record<'type', POOL_MENU_LINK>
+
+const PhishAlert = styled.div`
+  width: 100%;
+  padding: 6px 6px;
+  background-color: ${({ theme }) => theme.red1};
+  color: white;
+  font-size: 11px;
+  justify-content: space-between;
+  align-items: center;
+  display: flex;
+  margin-bottom: 10px;
+`
+
+const Alert = () => {
+  const { t } = useTranslation()
+
+  return isMobile ? (
+    <PhishAlert>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <AlertTriangle style={{ marginRight: 6 }} size={12} /> {t('elixir.auditWarning')}
+      </div>
+    </PhishAlert>
+  ) : (
+    <PhishAlert>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <AlertTriangle style={{ marginRight: 6 }} size={12} /> {t('elixir.auditWarning')}
+      </div>
+    </PhishAlert>
+  )
+}
 
 const Pool = () => {
   const params = useParams<PoolProps>()
+  const chainId = useChainId()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (chainId && shouldHideChildItem(chainId, MENU_LINK.pool, params?.type as POOL_MENU_LINK)) {
+      navigate('/')
+    }
+  }, [chainId, params?.type])
 
   if (params?.type === POOL_MENU_LINK.standard) {
     return <PoolsUI />
   }
 
   if (params?.type === POOL_MENU_LINK.elixir) {
-    return <Elixir />
+    return (
+      <>
+        <Alert />
+        <Elixir />
+      </>
+    )
   }
 
   return <PoolsUI />

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -72,7 +72,7 @@ export const shouldHideChildItem = (
   menuLink: CHILD_MENU_TYPES
 ): boolean => {
   const hideMenus = HIDE_CHILD_MENU_ACCESS_MANAGEMENT[chainId]
-  return hideMenus?.some(menu => `${parentMenuLink}/${menu}` === menuLink) ?? false
+  return hideMenus?.some(menu => `${parentMenuLink}/${menu}` === `${parentMenuLink}/${menuLink}`) ?? false
 }
 
 // account is not optional

--- a/yarn.lock
+++ b/yarn.lock
@@ -4025,10 +4025,10 @@
   dependencies:
     "@defi.org/web3-candies" "4.x"
 
-"@pangolindex/components@7.1.5-rc.0":
-  version "7.1.5-rc.0"
-  resolved "https://registry.yarnpkg.com/@pangolindex/components/-/components-7.1.5-rc.0.tgz#87e6d17bd0d4d79e809020d9d7a92420bce268cc"
-  integrity sha512-Mj6aZnLVcN8uyl9jBE9QJplIE9fbET0XytChkIGvI0zL4khk1+TjMl5KqlNp1+gSHqV1p41gUFtRZUL9UCW2mg==
+"@pangolindex/components@7.1.4-internal.3609196":
+  version "7.1.4-internal.3609196"
+  resolved "https://registry.yarnpkg.com/@pangolindex/components/-/components-7.1.4-internal.3609196.tgz#9893ee01231648a69eabbac0bb4cced5ba54fd13"
+  integrity sha512-0EvHN5zIVDEaedQunl9mnGe34bbHVGz5PDaQ7xBWnLI1rEUhs24jOCtkO111h0ZLDXP9iXVDYYMowLfBK55h7g==
   dependencies:
     "@0xsquid/sdk" "1.3.2"
     "@ethersproject/abi" "5.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4025,10 +4025,10 @@
   dependencies:
     "@defi.org/web3-candies" "4.x"
 
-"@pangolindex/components@7.1.4-internal.3609196":
-  version "7.1.4-internal.3609196"
-  resolved "https://registry.yarnpkg.com/@pangolindex/components/-/components-7.1.4-internal.3609196.tgz#9893ee01231648a69eabbac0bb4cced5ba54fd13"
-  integrity sha512-0EvHN5zIVDEaedQunl9mnGe34bbHVGz5PDaQ7xBWnLI1rEUhs24jOCtkO111h0ZLDXP9iXVDYYMowLfBK55h7g==
+"@pangolindex/components@7.1.5-rc.1":
+  version "7.1.5-rc.1"
+  resolved "https://registry.yarnpkg.com/@pangolindex/components/-/components-7.1.5-rc.1.tgz#463c645dc5f0609a1355dea687ac9d716d0562be"
+  integrity sha512-GnkZ7JC35fY2ZO/52fLTcmmTkTWMP4TF5Yg/tmQibYop/B2Qpwzg42BVko4hTlOD2c3Ep9ShTbAktJInuMdkTQ==
   dependencies:
     "@0xsquid/sdk" "1.3.2"
     "@ethersproject/abi" "5.6.4"


### PR DESCRIPTION
## Summary

- The unaudited warning appears on the Elixir page.
- Fixed Elixir navigation bug. Users can't directly access `/pool/elixir` from the URL for unsupported chains.

## Tasks
- https://app.clickup.com/t/866abqge4
- https://sharing.clickup.com/36619926/t/h/863gue81q/XNK3I4OKHFZKIV8